### PR TITLE
Add note about slow tsconfig options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,9 @@ yarn add -D react-docgen-typescript-plugin
 
 ## Usage
 
+> NOTE: The TypeScript compiler options `allowSyntheticDefaultImports` and `esModuleInterop` will make 
+> `react-docgen-typescript-plugin` a lot harder! Turn them off for faster build times.
+
 ```ts
 const ReactDocgenTypescriptPlugin = require("react-docgen-typescript-plugin");
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.1-canary.2.15b7a00.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install react-docgen-typescript-plugin@0.1.1-canary.2.15b7a00.0
  # or 
  yarn add react-docgen-typescript-plugin@0.1.1-canary.2.15b7a00.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
