### PR TITLE
add "include" and "exclude" options

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
   ],
   "dependencies": {
     "endent": "^2.0.1",
+    "micromatch": "^4.0.2",
     "react-docgen-typescript": "^1.16.6",
     "react-docgen-typescript-loader": "^3.7.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
+    "@types/micromatch": "^4.0.1",
     "@types/node": "^14.0.12",
     "@types/webpack": "^4.41.17",
     "@typescript-eslint/eslint-plugin": "2.31.0",

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ yarn add -D react-docgen-typescript-plugin
 
 ## Usage
 
-> NOTE: The TypeScript compiler options `allowSyntheticDefaultImports` and `esModuleInterop` will make 
+> NOTE: The TypeScript compiler options `allowSyntheticDefaultImports` and `esModuleInterop` will make
 > `react-docgen-typescript-plugin` a lot harder! Turn them off for faster build times.
 
 ```ts
@@ -43,6 +43,8 @@ This plugins support all parser options from [react-docgen-typescript](https://g
 | docgenCollectionName | string or null | Specify the docgen collection name to use. All docgen information will be collected into this global object. Set to `null` to disable.              | `STORYBOOK_REACT_CLASSES` |
 | setDisplayName       | boolean        | Set the components' display name. If you want to set display names yourself or are using another plugin to do this, you should disable this option. | `true`                    |
 | typePropName         | string         | Specify the name of the property for docgen info prop type.                                                                                         | `type`                    |
+| exclude              | glob[]         | Glob patterns to ignore and not generate docgen information for. (Great for ignoring large icon libraries)                                          | []                        |
+| include              | glob[]         | Glob patterns to generate docgen information for                                                                                                    | ['**/**.tsx']             |
 
 ## Prior Art
 


### PR DESCRIPTION
## Release Notes

New options:

- `include` - Glob patterns to generate docs for
- `exclude` - Glob patterns to ignore doc generation. Great for ignoring all of your Icons

## Canary Version

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.1-canary.3.90d42b6.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install react-docgen-typescript-plugin@0.1.1-canary.3.90d42b6.0
  # or 
  yarn add react-docgen-typescript-plugin@0.1.1-canary.3.90d42b6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
