### PR TITLE
Handle no options passed in

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -131,7 +131,7 @@ export default class DocgenPlugin {
   private name = "React Docgen Typescript Plugin";
   private options: PluginOptions;
 
-  constructor(options: PluginOptions) {
+  constructor(options: PluginOptions = {}) {
     this.options = options;
   }
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.1-canary.8.97e5556.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install react-docgen-typescript-plugin@0.4.1-canary.8.97e5556.0
  # or 
  yarn add react-docgen-typescript-plugin@0.4.1-canary.8.97e5556.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
