### PR TITLE
default to loading root tsconfig.json when no typescript configuration is provided

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,11 +23,12 @@ const ReactDocgenTypescriptPlugin = require("react-docgen-typescript-plugin");
 
 module.exports = {
   plugins: [
+    // Will default to loading your root tsconfig.json
     new ReactDocgenTypescriptPlugin(),
-    // or with a tsconfig
-    new ReactDocgenTypescriptPlugin({ tsconfigPath: "./tsconfig.json" }),
-    // or with options
-    new ReactDocgenTypescriptPlugin({ jsx: ts.JsxEmit.Preserve }),
+    // or with a specific tsconfig
+    new ReactDocgenTypescriptPlugin({ tsconfigPath: "./tsconfig.dev.json" }),
+    // or with compiler options
+    new ReactDocgenTypescriptPlugin({ compilerOptions: { jsx: ts.JsxEmit.Preserve } }),
   ],
 };
 ```


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.2-canary.9.7536c0f.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install react-docgen-typescript-plugin@0.4.2-canary.9.7536c0f.0
  # or 
  yarn add react-docgen-typescript-plugin@0.4.2-canary.9.7536c0f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
