### PR TITLE
glob against userRequest instead of request

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -191,14 +191,14 @@ export default class DocgenPlugin {
             return;
           }
 
-          if (isExcluded(module.request)) {
+          if (isExcluded(module.userRequest)) {
             debugExclude(
               `Module not matched in "exclude": ${module.userRequest}`
             );
             return;
           }
 
-          if (!isIncluded(module.request)) {
+          if (!isIncluded(module.userRequest)) {
             debugExclude(
               `Module not matched in "include": ${module.userRequest}`
             );


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.5.1-canary.10.d8068b5.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install react-docgen-typescript-plugin@0.5.1-canary.10.d8068b5.0
  # or 
  yarn add react-docgen-typescript-plugin@0.5.1-canary.10.d8068b5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
