### PR TITLE
update react-docgen-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "^4.1.1",
     "endent": "^2.0.1",
     "micromatch": "^4.0.2",
-    "react-docgen-typescript": "^1.16.6",
+    "react-docgen-typescript": "^1.20.1",
     "react-docgen-typescript-loader": "^3.7.2",
     "tslib": "^2.0.0"
   },


### PR DESCRIPTION
closes #11
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.5.2-canary.12.47f51e6.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-docgen-typescript-plugin@0.5.2-canary.12.47f51e6.0
  # or 
  yarn add react-docgen-typescript-plugin@0.5.2-canary.12.47f51e6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
