### PR TITLE
add docgen:docs debugging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,10 +55,14 @@ If you want to see how this plugins is including and excluding modules set the `
 - `DEBUG=docgen:*` - All logs
 - `DEBUG=docgen:include` - Included modules
 - `DEBUG=docgen:exclude` - Excluded modules
+- `DEBUG=docgen:docs` - Generated docs
 
 ```bash
 DEBUG=docgen:* npm run storybook
 ```
+
+> Another great way of debugging your generated docs is to use a `debugger` statement in your component source file.
+> If you turn off source maps you will be able to see the code that this package generates.
 
 ## Prior Art
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,6 +8,7 @@ import match from "micromatch";
 
 const debugExclude = createDebug("docgen:exclude");
 const debugInclude = createDebug("docgen:include");
+const debugDocs = createDebug("docgen:docs");
 
 interface TypescriptOptions {
   /**
@@ -100,6 +101,8 @@ function processModule(
     componentDocs,
     ...loaderOptions,
   }).substring(webpackModule.userRequest.length);
+
+  debugDocs(docs);
 
   // eslint-disable-next-line no-underscore-dangle
   let source = webpackModule._source._value;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.5.3-canary.13.57da91b.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-docgen-typescript-plugin@0.5.3-canary.13.57da91b.0
  # or 
  yarn add react-docgen-typescript-plugin@0.5.3-canary.13.57da91b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
