### PR TITLE
Fix include/exclude typings

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -59,9 +59,9 @@ export type PluginOptions = docGen.ParserOptions &
   LoaderOptions &
   TypescriptOptions & {
     /** Glob patterns to ignore */
-    exclude?: [];
+    exclude?: string[];
     /** Glob patterns to include. defaults to ts|tsx */
-    include?: [];
+    include?: string[];
   };
 
 interface Module {


### PR DESCRIPTION
Trying to use these in Storybook and it's giving me type errors.