### PR TITLE
copy generateDocgenCodeBlock from loader to remove dependency on archived code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,13 +4,27 @@
     "xo",
     "prettier",
     "plugin:@typescript-eslint/recommended",
-    "prettier/@typescript-eslint"
+    "prettier/@typescript-eslint",
+    "plugin:jest/recommended",
+    "plugin:jest/style"
   ],
-  "plugins": ["prettier", "eslint-plugin-jsdoc", "@typescript-eslint"],
+  "plugins": [
+    "prettier",
+    "eslint-plugin-jsdoc",
+    "@typescript-eslint",
+    "jest"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "./tsconfig.json",
     "sourceType": "module"
+  },
+  "ignorePatterns": [
+    "jest.config.js",
+    "**/__fixtures__"
+  ],
+  "env": {
+    "jest/globals": true
   },
   "rules": {
     "@typescript-eslint/explicit-function-return-type": 0,

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,6 +27,7 @@ jobs:
         yarn
         yarn build
         yarn lint
+        yarn test
 
   release:
     runs-on: ubuntu-latest

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.tsx?$": "ts-jest",
+  },
+  testRegex: "(/__tests__/.*|(.|/)).(test|spec).(jsx?|tsx?)$",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+};

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "author": "Andrew Lisowski <lisowski54@gmail.com>",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
     "start": "yarn build --watch",
     "lint": "eslint src --ext .ts,.js",
+    "test": "jest",
     "release": "auto shipit"
   },
   "keywords": [
@@ -27,13 +28,14 @@
     "endent": "^2.0.1",
     "micromatch": "^4.0.2",
     "react-docgen-typescript": "^1.20.1",
-    "react-docgen-typescript-loader": "^3.7.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",
+    "@types/jest": "^26.0.16",
     "@types/micromatch": "^4.0.1",
     "@types/node": "^14.0.12",
+    "@types/react": "^17.0.0",
     "@types/webpack": "^4.41.17",
     "@typescript-eslint/eslint-plugin": "2.31.0",
     "@typescript-eslint/parser": "2.31.0",
@@ -44,10 +46,14 @@
     "eslint-config-prettier": "6.11.0",
     "eslint-config-xo": "0.29.1",
     "eslint-plugin-import": "2.20.2",
+    "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-jsdoc": "25.2.0",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-prettier": "3.1.3",
+    "jest": "^26.6.3",
     "prettier": "^2.0.5",
+    "react": "^17.0.1",
+    "ts-jest": "^26.4.4",
     "typescript": "3.8.3"
   },
   "peerDependencies": {

--- a/src/__tests__/__fixtures__/DefaultPropValue.tsx
+++ b/src/__tests__/__fixtures__/DefaultPropValue.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+
+interface DefaultPropValueComponentProps {
+  /**
+   * Button color.
+   *
+   * @default blue
+   **/
+  color: "blue" | "green";
+
+  /**
+   * Button counter.
+   */
+  counter: number;
+
+  /**
+   * Button disabled.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Component with a prop with a default value.
+ */
+export const DefaultPropValueComponent: React.FC<DefaultPropValueComponentProps> = (
+  props
+) => (
+  <button disabled={props.disabled} style={{ backgroundColor: props.color }}>
+    {props.counter}
+    {props.children}
+  </button>
+);
+
+DefaultPropValueComponent.defaultProps = {
+  counter: 123,
+  disabled: false,
+};

--- a/src/__tests__/__fixtures__/HyphenatedPropName.tsx
+++ b/src/__tests__/__fixtures__/HyphenatedPropName.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+interface HyphenatedPropNameProps {
+  /** Button color. */
+  "button-color": "blue" | "green";
+}
+
+/**
+ * A component with a hyphenated prop name.
+ */
+export const HyphenatedPropNameComponent: React.FC<HyphenatedPropNameProps> = (
+  props
+) => (
+  <button style={{ backgroundColor: props["button-color"] }}>
+    {props.children}
+  </button>
+);

--- a/src/__tests__/__fixtures__/MultiProps.tsx
+++ b/src/__tests__/__fixtures__/MultiProps.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+interface MultiPropsComponentProps {
+  /** Button color. */
+  color: "blue" | "green";
+
+  /** Button size. */
+  size: "small" | "large";
+}
+
+/**
+ * This is a component with multiple props.
+ */
+export const MultiPropsComponent: React.FC<MultiPropsComponentProps> = (
+  props
+) => <button style={{ backgroundColor: props.color }}>{props.children}</button>;

--- a/src/__tests__/__fixtures__/MultilineDescription.tsx
+++ b/src/__tests__/__fixtures__/MultilineDescription.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+
+interface MultilineDescriptionProps {
+  /** Button color. */
+  color: "blue" | "green";
+}
+
+/**
+ * A component with a multiline description.
+ *
+ * Second line.
+ */
+export const MultilineDescriptionComponent: React.FC<MultilineDescriptionProps> = (
+  props
+) => <button style={{ backgroundColor: props.color }}>{props.children}</button>;

--- a/src/__tests__/__fixtures__/MultilinePropDescription.tsx
+++ b/src/__tests__/__fixtures__/MultilinePropDescription.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+interface MultilinePropDescriptionComponentProps {
+  /**
+   * This is a multiline prop description.
+   *
+   * Second line.
+   */
+  color: "blue" | "green";
+}
+
+/**
+ * A component with multiline prop description.
+ */
+export const MultilinePropDescriptionComponent: React.FC<MultilinePropDescriptionComponentProps> = (
+  props
+) => <button style={{ backgroundColor: props.color }}>{props.children}</button>;

--- a/src/__tests__/__fixtures__/Simple.tsx
+++ b/src/__tests__/__fixtures__/Simple.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+interface SimpleComponentProps {
+  /** Button color. */
+  color: "blue" | "green";
+}
+
+/**
+ * A simple component.
+ */
+export const SimpleComponent: React.FC<SimpleComponentProps> = (props) => (
+  <button style={{ backgroundColor: props.color }}>{props.children}</button>
+);

--- a/src/__tests__/__fixtures__/TextOnlyComponent.tsx
+++ b/src/__tests__/__fixtures__/TextOnlyComponent.tsx
@@ -1,0 +1,10 @@
+import * as React from "react";
+
+/**
+ * A component with only text content wrapped in a div.
+ *
+ * Ref: https://github.com/strothj/react-docgen-typescript-loader/issues/7
+ */
+export const SimpleComponent: React.FC<{}> = () => (
+  <div>Test only component</div>
+);

--- a/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
+++ b/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
@@ -1,0 +1,279 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`adds component to docgen collection 1`] = `
+"import * as React from \\"react\\";
+
+interface SimpleComponentProps {
+  /** Button color. */
+  color: \\"blue\\" | \\"green\\";
+}
+
+/**
+ * A simple component.
+ */
+export const SimpleComponent: React.FC<SimpleComponentProps> = (props) => (
+  <button style={{ backgroundColor: props.color }}>{props.children}</button>
+);
+
+try {
+    // @ts-ignore
+    SimpleComponent.displayName = \\"SimpleComponent\\";
+    // @ts-ignore
+    SimpleComponent.__docgenInfo = { \\"description\\": \\"A simple component.\\", \\"displayName\\": \\"SimpleComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+    // @ts-ignore
+    if (typeof STORYBOOK_REACT_CLASSES !== \\"undefined\\")
+        // @ts-ignore
+        STORYBOOK_REACT_CLASSES[\\"Simple.tsx#SimpleComponent\\"] = { docgenInfo: SimpleComponent.__docgenInfo, name: \\"SimpleComponent\\", path: \\"Simple.tsx#SimpleComponent\\" };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
+exports[`component fixture DefaultPropValue.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface DefaultPropValueComponentProps {
+  /**
+   * Button color.
+   *
+   * @default blue
+   **/
+  color: \\"blue\\" | \\"green\\";
+
+  /**
+   * Button counter.
+   */
+  counter: number;
+
+  /**
+   * Button disabled.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Component with a prop with a default value.
+ */
+export const DefaultPropValueComponent: React.FC<DefaultPropValueComponentProps> = (
+  props
+) => (
+  <button disabled={props.disabled} style={{ backgroundColor: props.color }}>
+    {props.counter}
+    {props.children}
+  </button>
+);
+
+DefaultPropValueComponent.defaultProps = {
+  counter: 123,
+  disabled: false,
+};
+
+try {
+    // @ts-ignore
+    DefaultPropValueComponent.displayName = \\"DefaultPropValueComponent\\";
+    // @ts-ignore
+    DefaultPropValueComponent.__docgenInfo = { \\"description\\": \\"Component with a prop with a default value.\\", \\"displayName\\": \\"DefaultPropValueComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": { value: \\"blue\\" }, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } }, \\"counter\\": { \\"defaultValue\\": { value: 123 }, \\"description\\": \\"Button counter.\\", \\"name\\": \\"counter\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"number\\" } }, \\"disabled\\": { \\"defaultValue\\": { value: false }, \\"description\\": \\"Button disabled.\\", \\"name\\": \\"disabled\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"boolean\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
+exports[`component fixture HyphenatedPropName.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface HyphenatedPropNameProps {
+  /** Button color. */
+  \\"button-color\\": \\"blue\\" | \\"green\\";
+}
+
+/**
+ * A component with a hyphenated prop name.
+ */
+export const HyphenatedPropNameComponent: React.FC<HyphenatedPropNameProps> = (
+  props
+) => (
+  <button style={{ backgroundColor: props[\\"button-color\\"] }}>
+    {props.children}
+  </button>
+);
+
+try {
+    // @ts-ignore
+    HyphenatedPropNameComponent.displayName = \\"HyphenatedPropNameComponent\\";
+    // @ts-ignore
+    HyphenatedPropNameComponent.__docgenInfo = { \\"description\\": \\"A component with a hyphenated prop name.\\", \\"displayName\\": \\"HyphenatedPropNameComponent\\", \\"props\\": { \\"button-color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"button-color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
+exports[`component fixture MultiProps.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface MultiPropsComponentProps {
+  /** Button color. */
+  color: \\"blue\\" | \\"green\\";
+
+  /** Button size. */
+  size: \\"small\\" | \\"large\\";
+}
+
+/**
+ * This is a component with multiple props.
+ */
+export const MultiPropsComponent: React.FC<MultiPropsComponentProps> = (
+  props
+) => <button style={{ backgroundColor: props.color }}>{props.children}</button>;
+
+try {
+    // @ts-ignore
+    MultiPropsComponent.displayName = \\"MultiPropsComponent\\";
+    // @ts-ignore
+    MultiPropsComponent.__docgenInfo = { \\"description\\": \\"This is a component with multiple props.\\", \\"displayName\\": \\"MultiPropsComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } }, \\"size\\": { \\"defaultValue\\": null, \\"description\\": \\"Button size.\\", \\"name\\": \\"size\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"small\\\\\\" | \\\\\\"large\\\\\\"\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
+exports[`component fixture MultilineDescription.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface MultilineDescriptionProps {
+  /** Button color. */
+  color: \\"blue\\" | \\"green\\";
+}
+
+/**
+ * A component with a multiline description.
+ *
+ * Second line.
+ */
+export const MultilineDescriptionComponent: React.FC<MultilineDescriptionProps> = (
+  props
+) => <button style={{ backgroundColor: props.color }}>{props.children}</button>;
+
+try {
+    // @ts-ignore
+    MultilineDescriptionComponent.displayName = \\"MultilineDescriptionComponent\\";
+    // @ts-ignore
+    MultilineDescriptionComponent.__docgenInfo = { \\"description\\": \\"A component with a multiline description.\\\\n\\\\nSecond line.\\", \\"displayName\\": \\"MultilineDescriptionComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
+exports[`component fixture MultilinePropDescription.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface MultilinePropDescriptionComponentProps {
+  /**
+   * This is a multiline prop description.
+   *
+   * Second line.
+   */
+  color: \\"blue\\" | \\"green\\";
+}
+
+/**
+ * A component with multiline prop description.
+ */
+export const MultilinePropDescriptionComponent: React.FC<MultilinePropDescriptionComponentProps> = (
+  props
+) => <button style={{ backgroundColor: props.color }}>{props.children}</button>;
+
+try {
+    // @ts-ignore
+    MultilinePropDescriptionComponent.displayName = \\"MultilinePropDescriptionComponent\\";
+    // @ts-ignore
+    MultilinePropDescriptionComponent.__docgenInfo = { \\"description\\": \\"A component with multiline prop description.\\", \\"displayName\\": \\"MultilinePropDescriptionComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"This is a multiline prop description.\\\\n\\\\nSecond line.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
+exports[`component fixture Simple.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface SimpleComponentProps {
+  /** Button color. */
+  color: \\"blue\\" | \\"green\\";
+}
+
+/**
+ * A simple component.
+ */
+export const SimpleComponent: React.FC<SimpleComponentProps> = (props) => (
+  <button style={{ backgroundColor: props.color }}>{props.children}</button>
+);
+
+try {
+    // @ts-ignore
+    SimpleComponent.displayName = \\"SimpleComponent\\";
+    // @ts-ignore
+    SimpleComponent.__docgenInfo = { \\"description\\": \\"A simple component.\\", \\"displayName\\": \\"SimpleComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
+exports[`component fixture TextOnlyComponent.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+/**
+ * A component with only text content wrapped in a div.
+ *
+ * Ref: https://github.com/strothj/react-docgen-typescript-loader/issues/7
+ */
+export const SimpleComponent: React.FC<{}> = () => (
+  <div>Test only component</div>
+);
+
+try {
+    // @ts-ignore
+    SimpleComponent.displayName = \\"SimpleComponent\\";
+    // @ts-ignore
+    SimpleComponent.__docgenInfo = { \\"description\\": \\"A component with only text content wrapped in a div.\\\\n\\\\nRef: https://github.com/strothj/react-docgen-typescript-loader/issues/7\\", \\"displayName\\": \\"SimpleComponent\\", \\"props\\": {} };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
+exports[`generates value info for enums 1`] = `
+"import * as React from \\"react\\";
+
+interface DefaultPropValueComponentProps {
+  /**
+   * Button color.
+   *
+   * @default blue
+   **/
+  color: \\"blue\\" | \\"green\\";
+
+  /**
+   * Button counter.
+   */
+  counter: number;
+
+  /**
+   * Button disabled.
+   */
+  disabled: boolean;
+}
+
+/**
+ * Component with a prop with a default value.
+ */
+export const DefaultPropValueComponent: React.FC<DefaultPropValueComponentProps> = (
+  props
+) => (
+  <button disabled={props.disabled} style={{ backgroundColor: props.color }}>
+    {props.counter}
+    {props.children}
+  </button>
+);
+
+DefaultPropValueComponent.defaultProps = {
+  counter: 123,
+  disabled: false,
+};
+
+try {
+    // @ts-ignore
+    DefaultPropValueComponent.displayName = \\"DefaultPropValueComponent\\";
+    // @ts-ignore
+    DefaultPropValueComponent.__docgenInfo = { \\"description\\": \\"Component with a prop with a default value.\\", \\"displayName\\": \\"DefaultPropValueComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": { value: \\"blue\\" }, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"enum\\", \\"value\\": [{ \\"value\\": \\"\\\\\\"blue\\\\\\"\\" }, { \\"value\\": \\"\\\\\\"green\\\\\\"\\" }] } }, \\"counter\\": { \\"defaultValue\\": { value: 123 }, \\"description\\": \\"Button counter.\\", \\"name\\": \\"counter\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"number\\" } }, \\"disabled\\": { \\"defaultValue\\": { value: false }, \\"description\\": \\"Button disabled.\\", \\"name\\": \\"disabled\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"boolean\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;

--- a/src/__tests__/generateDocgenCodeBlock.test.ts
+++ b/src/__tests__/generateDocgenCodeBlock.test.ts
@@ -1,7 +1,8 @@
 import fs from "fs";
 import path from "path";
 import { parse, ParserOptions } from "react-docgen-typescript/lib/parser.js";
-import generateDocgenCodeBlock, {
+import {
+  generateDocgenCodeBlock,
   GeneratorOptions,
 } from "../generateDocgenCodeBlock";
 

--- a/src/__tests__/generateDocgenCodeBlock.test.ts
+++ b/src/__tests__/generateDocgenCodeBlock.test.ts
@@ -1,0 +1,59 @@
+import fs from "fs";
+import path from "path";
+import { parse, ParserOptions } from "react-docgen-typescript/lib/parser.js";
+import generateDocgenCodeBlock, {
+  GeneratorOptions,
+} from "../generateDocgenCodeBlock";
+
+function getGeneratorOptions(parserOptions: ParserOptions = {}) {
+  return (filename: string) => {
+    const filePath = path.resolve(__dirname, "__fixtures__", filename);
+
+    return {
+      filename,
+      source: fs.readFileSync(filePath, "utf8"),
+      componentDocs: parse(filePath, parserOptions),
+      docgenCollectionName: null,
+      setDisplayName: true,
+      typePropName: "type",
+    } as GeneratorOptions;
+  };
+}
+
+function loadFixtureTests(): GeneratorOptions[] {
+  return fs
+    .readdirSync(path.resolve(__dirname, "__fixtures__"))
+    .map(getGeneratorOptions());
+}
+
+const fixtureTests: GeneratorOptions[] = loadFixtureTests();
+const simpleFixture = fixtureTests.find(
+  (f) => f.filename === "Simple.tsx"
+) as GeneratorOptions;
+
+describe("component fixture", () => {
+  fixtureTests.forEach((generatorOptions) => {
+    it(`${generatorOptions.filename} has code block generated`, () => {
+      expect(generateDocgenCodeBlock(generatorOptions)).toMatchSnapshot();
+    });
+  });
+});
+
+it("adds component to docgen collection", () => {
+  expect(
+    generateDocgenCodeBlock({
+      ...simpleFixture,
+      docgenCollectionName: "STORYBOOK_REACT_CLASSES",
+    })
+  ).toMatchSnapshot();
+});
+
+it("generates value info for enums", () => {
+  expect(
+    generateDocgenCodeBlock(
+      getGeneratorOptions({ shouldExtractLiteralValuesFromEnum: true })(
+        "DefaultPropValue.tsx"
+      )
+    )
+  ).toMatchSnapshot();
+});

--- a/src/generateDocgenCodeBlock.ts
+++ b/src/generateDocgenCodeBlock.ts
@@ -321,9 +321,7 @@ export interface GeneratorOptions {
   typePropName: string;
 }
 
-export default function generateDocgenCodeBlock(
-  options: GeneratorOptions
-): string {
+export function generateDocgenCodeBlock(options: GeneratorOptions): string {
   const sourceFile = ts.createSourceFile(
     options.filename,
     options.source,

--- a/src/generateDocgenCodeBlock.ts
+++ b/src/generateDocgenCodeBlock.ts
@@ -1,0 +1,381 @@
+import path from "path";
+import ts from "typescript";
+import { ComponentDoc, PropItem } from "react-docgen-typescript";
+
+/**
+ * Inserts a ts-ignore comment above the supplied statement.
+ *
+ * It is used to work around type errors related to fields like __docgenInfo not
+ * being defined on types. It also prevents compile errors related to attempting
+ * to assign to nonexistent components, which can happen due to incorrect
+ * detection of component names when using the parser.
+ * ```
+ * // @ts-ignore
+ * ```
+ * @param statement
+ */
+function insertTsIgnoreBeforeStatement(statement: ts.Statement): ts.Statement {
+  ts.setSyntheticLeadingComments(statement, [
+    {
+      text: " @ts-ignore", // Leading space is important here
+      kind: ts.SyntaxKind.SingleLineCommentTrivia,
+      pos: -1,
+      end: -1,
+    },
+  ]);
+  return statement;
+}
+
+/**
+ * Set component display name.
+ *
+ * ```
+ * SimpleComponent.displayName = "SimpleComponent";
+ * ```
+ */
+function setDisplayName(d: ComponentDoc): ts.Statement {
+  return insertTsIgnoreBeforeStatement(
+    ts.createExpressionStatement(
+      ts.createBinary(
+        ts.createPropertyAccess(
+          ts.createIdentifier(d.displayName),
+          ts.createIdentifier("displayName")
+        ),
+        ts.SyntaxKind.EqualsToken,
+        ts.createLiteral(d.displayName)
+      )
+    )
+  );
+}
+
+/**
+ * Set a component prop description.
+ * ```
+ * SimpleComponent.__docgenInfo.props.someProp = {
+ *   defaultValue: "blue",
+ *   description: "Prop description.",
+ *   name: "someProp",
+ *   required: true,
+ *   type: "'blue' | 'green'",
+ * }
+ * ```
+ *
+ * @param propName Prop name
+ * @param prop Prop definition from `ComponentDoc.props`
+ * @param options Generator options.
+ */
+function createPropDefinition(
+  propName: string,
+  prop: PropItem,
+  options: GeneratorOptions
+) {
+  /**
+   * Set default prop value.
+   *
+   * ```
+   * SimpleComponent.__docgenInfo.props.someProp.defaultValue = null;
+   * SimpleComponent.__docgenInfo.props.someProp.defaultValue = {
+   *   value: "blue",
+   * };
+   * ```
+   *
+   * @param defaultValue Default prop value or null if not set.
+   */
+  const setDefaultValue = (
+    defaultValue: { value: string | number | boolean } | null
+  ) =>
+    ts.createPropertyAssignment(
+      ts.createLiteral("defaultValue"),
+      // Use a more extensive check on defaultValue. Sometimes the parser
+      // returns an empty object.
+      defaultValue !== null &&
+        defaultValue !== undefined &&
+        typeof defaultValue === "object" &&
+        "value" in defaultValue &&
+        (typeof defaultValue.value === "string" ||
+          typeof defaultValue.value === "number" ||
+          typeof defaultValue.value === "boolean")
+        ? ts.createObjectLiteral([
+            ts.createPropertyAssignment(
+              ts.createIdentifier("value"),
+              ts.createLiteral(defaultValue.value)
+            ),
+          ])
+        : ts.createNull()
+    );
+
+  /** Set a property with a string value */
+  const setStringLiteralField = (fieldName: string, fieldValue: string) =>
+    ts.createPropertyAssignment(
+      ts.createLiteral(fieldName),
+      ts.createLiteral(fieldValue)
+    );
+
+  /**
+   * ```
+   * SimpleComponent.__docgenInfo.props.someProp.description = "Prop description.";
+   * ```
+   * @param description Prop description.
+   */
+  const setDescription = (description: string) =>
+    setStringLiteralField("description", description);
+
+  /**
+   * ```
+   * SimpleComponent.__docgenInfo.props.someProp.name = "someProp";
+   * ```
+   * @param name Prop name.
+   */
+  const setName = (name: string) => setStringLiteralField("name", name);
+
+  /**
+   * ```
+   * SimpleComponent.__docgenInfo.props.someProp.required = true;
+   * ```
+   * @param required Whether prop is required or not.
+   */
+  const setRequired = (required: boolean) =>
+    ts.createPropertyAssignment(
+      ts.createLiteral("required"),
+      required ? ts.createTrue() : ts.createFalse()
+    );
+
+  /**
+   * ```
+   * SimpleComponent.__docgenInfo.props.someProp.type = {
+   *  name: "enum",
+   *  value: [ { value: "\"blue\"" }, { value: "\"green\""} ]
+   * }
+   * ```
+   * @param [typeValue] Prop value (for enums)
+   */
+  const setValue = (typeValue?: any[]) =>
+    Array.isArray(typeValue) &&
+    typeValue.every((value) => typeof value.value === "string")
+      ? ts.createPropertyAssignment(
+          ts.createLiteral("value"),
+          ts.createArrayLiteral(
+            typeValue.map((value) =>
+              ts.createObjectLiteral([
+                setStringLiteralField("value", value.value),
+              ])
+            )
+          )
+        )
+      : undefined;
+
+  /**
+   * ```
+   * SimpleComponent.__docgenInfo.props.someProp.type = { name: "'blue' | 'green'"}
+   * ```
+   * @param typeName Prop type name.
+   * @param [typeValue] Prop value (for enums)
+   */
+  const setType = (typeName: string, typeValue?: any[]) => {
+    const objectFields = [setStringLiteralField("name", typeName)];
+    const valueField = setValue(typeValue);
+
+    if (valueField) {
+      objectFields.push(valueField);
+    }
+
+    return ts.createPropertyAssignment(
+      ts.createLiteral(options.typePropName),
+      ts.createObjectLiteral(objectFields)
+    );
+  };
+
+  return ts.createPropertyAssignment(
+    ts.createLiteral(propName),
+    ts.createObjectLiteral([
+      setDefaultValue(prop.defaultValue),
+      setDescription(prop.description),
+      setName(prop.name),
+      setRequired(prop.required),
+      setType(prop.type.name, prop.type.value),
+    ])
+  );
+}
+
+/**
+ * Adds a component's docgen info to the global docgen collection.
+ *
+ * ```
+ * if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
+ *   STORYBOOK_REACT_CLASSES["src/.../SimpleComponent.tsx"] = {
+ *     name: "SimpleComponent",
+ *     docgenInfo: SimpleComponent.__docgenInfo,
+ *     path: "src/.../SimpleComponent.tsx",
+ *   };
+ * }
+ * ```
+ *
+ * @param d Component doc.
+ * @param docgenCollectionName Global docgen collection variable name.
+ * @param relativeFilename Relative file path of the component source file.
+ */
+function insertDocgenIntoGlobalCollection(
+  d: ComponentDoc,
+  docgenCollectionName: string,
+  relativeFilename: string
+): ts.Statement {
+  return insertTsIgnoreBeforeStatement(
+    ts.createIf(
+      ts.createBinary(
+        ts.createTypeOf(ts.createIdentifier(docgenCollectionName)),
+        ts.SyntaxKind.ExclamationEqualsEqualsToken,
+        ts.createLiteral("undefined")
+      ),
+      insertTsIgnoreBeforeStatement(
+        ts.createStatement(
+          ts.createBinary(
+            ts.createElementAccess(
+              ts.createIdentifier(docgenCollectionName),
+              ts.createLiteral(`${relativeFilename}#${d.displayName}`)
+            ),
+            ts.SyntaxKind.EqualsToken,
+            ts.createObjectLiteral([
+              ts.createPropertyAssignment(
+                ts.createIdentifier("docgenInfo"),
+                ts.createPropertyAccess(
+                  ts.createIdentifier(d.displayName),
+                  ts.createIdentifier("__docgenInfo")
+                )
+              ),
+              ts.createPropertyAssignment(
+                ts.createIdentifier("name"),
+                ts.createLiteral(d.displayName)
+              ),
+              ts.createPropertyAssignment(
+                ts.createIdentifier("path"),
+                ts.createLiteral(`${relativeFilename}#${d.displayName}`)
+              ),
+            ])
+          )
+        )
+      )
+    )
+  );
+}
+
+/**
+ * Sets the field `__docgenInfo` for the component specified by the component
+ * doc with the docgen information.
+ *
+ * ```
+ * SimpleComponent.__docgenInfo = {
+ *   description: ...,
+ *   displayName: ...,
+ *   props: ...,
+ * }
+ * ```
+ *
+ * @param d Component doc.
+ * @param options Generator options.
+ */
+function setComponentDocGen(
+  d: ComponentDoc,
+  options: GeneratorOptions
+): ts.Statement {
+  return insertTsIgnoreBeforeStatement(
+    ts.createStatement(
+      ts.createBinary(
+        // SimpleComponent.__docgenInfo
+        ts.createPropertyAccess(
+          ts.createIdentifier(d.displayName),
+          ts.createIdentifier("__docgenInfo")
+        ),
+        ts.SyntaxKind.EqualsToken,
+        ts.createObjectLiteral([
+          // SimpleComponent.__docgenInfo.description
+          ts.createPropertyAssignment(
+            ts.createLiteral("description"),
+            ts.createLiteral(d.description)
+          ),
+          // SimpleComponent.__docgenInfo.displayName
+          ts.createPropertyAssignment(
+            ts.createLiteral("displayName"),
+            ts.createLiteral(d.displayName)
+          ),
+          // SimpleComponent.__docgenInfo.props
+          ts.createPropertyAssignment(
+            ts.createLiteral("props"),
+            ts.createObjectLiteral(
+              Object.entries(d.props).map(([propName, prop]) =>
+                createPropDefinition(propName, prop, options)
+              )
+            )
+          ),
+        ])
+      )
+    )
+  );
+}
+
+export interface GeneratorOptions {
+  filename: string;
+  source: string;
+  componentDocs: ComponentDoc[];
+  docgenCollectionName: string | null;
+  setDisplayName: boolean;
+  typePropName: string;
+}
+
+export default function generateDocgenCodeBlock(
+  options: GeneratorOptions
+): string {
+  const sourceFile = ts.createSourceFile(
+    options.filename,
+    options.source,
+    ts.ScriptTarget.ESNext
+  );
+
+  const relativeFilename = path
+    .relative("./", path.resolve("./", options.filename))
+    .replace(/\\/g, "/");
+
+  const wrapInTryStatement = (statements: ts.Statement[]): ts.TryStatement =>
+    ts.createTry(
+      ts.createBlock(statements, true),
+      ts.createCatchClause(
+        ts.createVariableDeclaration(
+          ts.createIdentifier("__react_docgen_typescript_loader_error")
+        ),
+        ts.createBlock([])
+      ),
+      undefined
+    );
+
+  const codeBlocks = options.componentDocs.map((d) =>
+    wrapInTryStatement(
+      [
+        options.setDisplayName ? setDisplayName(d) : null,
+        setComponentDocGen(d, options),
+        options.docgenCollectionName === null ||
+        options.docgenCollectionName === undefined
+          ? null
+          : insertDocgenIntoGlobalCollection(
+              d,
+              options.docgenCollectionName,
+              relativeFilename
+            ),
+      ].filter((s) => s !== null) as ts.Statement[]
+    )
+  );
+
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  const printNode = (sourceNode: ts.Node) =>
+    printer.printNode(ts.EmitHint.Unspecified, sourceNode, sourceFile);
+
+  // Concat original source code with code from generated code blocks.
+  const result = codeBlocks.reduce(
+    (acc, node) => `${acc}\n${printNode(node)}`,
+
+    // Use original source text rather than using printNode on the parsed form
+    // to prevent issue where literals are stripped within components.
+    // Ref: https://github.com/strothj/react-docgen-typescript-loader/issues/7
+    options.source
+  );
+
+  return result;
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,8 +3,9 @@ import createDebug from "debug";
 import * as webpack from "webpack";
 import ts from "typescript";
 import * as docGen from "react-docgen-typescript";
-import generateDocgenCodeBlock from "react-docgen-typescript-loader/dist/generateDocgenCodeBlock";
 import { matcher } from "micromatch";
+
+import { generateDocgenCodeBlock } from "./generateDocgenCodeBlock";
 
 const debugExclude = createDebug("docgen:exclude");
 const debugInclude = createDebug("docgen:include");

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,7 +7,7 @@
     "noEmit": false
   },
   "exclude": [
-    "**/*.spec.ts",
+    "**/*.test.ts",
     "**/__fixtures__",
     "**/__mocks__"
   ]

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "noEmit": false
+  },
+  "exclude": [
+    "**/*.spec.ts",
+    "**/__fixtures__",
+    "**/__mocks__"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "lib": ["esnext"],
     "outDir": "./dist",
     "rootDir": "./src",
+    "jsx": "react",
     "declaration": true,
     "declarationMap": true,
     "strict": true,


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.3-canary.19.84fb15f6641c9948ea0feb62ea1ebd3c9cd45419.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-docgen-typescript-plugin@0.6.3-canary.19.84fb15f6641c9948ea0feb62ea1ebd3c9cd45419.0
  # or 
  yarn add react-docgen-typescript-plugin@0.6.3-canary.19.84fb15f6641c9948ea0feb62ea1ebd3c9cd45419.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
