### PR TITLE
Include dotfiles in micromatch globs

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -153,7 +153,7 @@ function getTSConfigFile(tsconfigPath: string): ts.ParsedCommandLine {
 
 /** Create a glob matching function. */
 const matchGlob = (globs: string[]) => {
-  const matchers = globs.map((g) => matcher(g));
+  const matchers = globs.map((g) => matcher(g, { dot: true }));
   return (filename: string) =>
     Boolean(filename && matchers.find((match) => match(filename)));
 };


### PR DESCRIPTION
In Yarn 2 with PnP enabled, workpace packages are resolved with a virtual path located under the project `.yarn` folder, like

```
.yarn/$$virtual/@your-package-virtual/...
```

This causes docgen to skip inspecting the types for stories written outside of a package's workspace since by default, micromatch has `dot: false` in its options. This PR updates the matcher to set this value to `true` .

A slightly more complicated option that wouldn't decrease glob perf for non-Yarn users is to set the default glob to

```
  include: ['**/*.tsx', '**/.yarn/**/*.tsx']
```

P.S.  
If you're a Storybook user using Yarn 2, you can fix type generation for your workspaces by including the following snippet in your main.js file:

```javascript
module.exports = {
  typescript: {
    reactDocgenTypescriptOptions: {
      include: ['**/*.tsx', '**/.yarn/__virtual__/**/*.tsx'],
    },
  }
}
```