### PR TITLE
typescript 4.3.2 fails with react-docgen-typescript < 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "find-cache-dir": "^3.3.1",
     "flat-cache": "^3.0.4",
     "micromatch": "^4.0.2",
-    "react-docgen-typescript": "^1.22.0",
+    "react-docgen-typescript": "^2.0.0",
     "tslib": "^2.0.0",
     "webpack-sources": "^2.2.0"
   },


### PR DESCRIPTION
and thus @storybook/react fails because this plugin is/was using react-docgen-typescript 1.22.0

Referenced Issue: https://github.com/hipstersmoothie/react-docgen-typescript-plugin/issues/43