### PR TITLE
fix: respect falsy custom options

### DIFF
--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -1,6 +1,7 @@
 import webpack, { Configuration } from "webpack";
 import { createFsFromVolume, IFs, Volume } from "memfs";
 import ReactDocgenTypeScriptPlugin from "..";
+import { LoaderOptions } from "../types";
 
 // eslint-disable-next-line
 const joinPath = require("memory-fs/lib/join");
@@ -83,4 +84,35 @@ test("default options", async () => {
   const result = await compile(getConfig({}));
 
   expect(result).toContain("STORYBOOK_REACT_CLASSES");
+});
+
+describe("custom options", () => {
+  describe("loader options", () => {
+    const options: Record<
+      keyof LoaderOptions,
+      Array<LoaderOptions[keyof LoaderOptions]>
+    > = {
+      setDisplayName: [true, false, undefined],
+      typePropName: ["customValue", undefined],
+      docgenCollectionName: ["customValue", null, undefined],
+    };
+    const { defaultOptions } = ReactDocgenTypeScriptPlugin;
+
+    (Object.keys(options) as Array<keyof LoaderOptions>).forEach(
+      (optionName) => {
+        const values = options[optionName];
+
+        test.each(values)(`${optionName}: %p`, (value) => {
+          const plugin = new ReactDocgenTypeScriptPlugin({
+            [optionName]: value,
+          });
+          const { generateOptions: resultOptions } = plugin.getOptions();
+
+          expect(resultOptions[optionName]).toBe(
+            value === undefined ? defaultOptions[optionName] : value
+          );
+        });
+      }
+    );
+  });
 });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -135,6 +135,12 @@ function processModule(
 
 /** Inject typescript docgen information into modules at the end of a build */
 export default class DocgenPlugin implements webpack.WebpackPluginInstance {
+  public static defaultOptions = {
+    setDisplayName: true,
+    typePropName: "type",
+    docgenCollectionName: "STORYBOOK_REACT_CLASSES",
+  };
+
   private name = "React Docgen Typescript Plugin";
   private options: PluginOptions;
 
@@ -266,6 +272,7 @@ export default class DocgenPlugin implements webpack.WebpackPluginInstance {
       typePropName,
       ...docgenOptions
     } = this.options;
+    const { defaultOptions } = DocgenPlugin;
 
     let compilerOptions = {
       jsx: ts.JsxEmit.React,
@@ -286,9 +293,12 @@ export default class DocgenPlugin implements webpack.WebpackPluginInstance {
     return {
       docgenOptions,
       generateOptions: {
-        docgenCollectionName: docgenCollectionName || "STORYBOOK_REACT_CLASSES",
-        setDisplayName: setDisplayName || true,
-        typePropName: typePropName || "type",
+        docgenCollectionName:
+          docgenCollectionName === undefined
+            ? defaultOptions.docgenCollectionName
+            : docgenCollectionName,
+        setDisplayName: setDisplayName ?? defaultOptions.setDisplayName,
+        typePropName: typePropName ?? defaultOptions.typePropName,
       },
       compilerOptions,
     };


### PR DESCRIPTION
Hello!

It seems like since `1.0.0` falsy custom options have stopped being applied. I added a test that fails without suggested changes.

I found it after updating to storybook@6.3.0 and an investigation has led me here. In my project I set `setDisplayName` to `false`, but its not working anymore.