### PR TITLE
fix - Restore recompilation performance for webpack 4/5

### DIFF
--- a/src/dependency.ts
+++ b/src/dependency.ts
@@ -46,6 +46,7 @@ class DocGenTemplate extends NullDependency.Template
   };
 }
 
+// eslint-disable-next-line
 // @ts-ignore TODO: How to type this correctly?
 DocGenDependency.Template = DocGenTemplate;
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -185,8 +185,15 @@ export default class DocgenPlugin implements webpack.WebpackPluginInstance {
 
           // 1. Aggregate modules to process
           compilation.modules.forEach((module: webpack.Module) => {
-            // Ignore already built modules (webpack 4 only!).
-            // The question is, how to do the same in webpack 5?
+            // Ignore already built modules for webpack 5
+            if (isWebpack5 && compilation.builtModules.has(module)) {
+              // eslint-disable-next-line
+              // @ts-ignore: Webpack 4 type
+              debugExclude(`Ignoring un-built module: ${module.userRequest}`);
+              return;
+            }
+
+            // Ignore already built modules for webpack 4
             // eslint-disable-next-line
             // @ts-ignore: Webpack 4 type
             if (!isWebpack5 && !module.built) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -186,7 +186,7 @@ export default class DocgenPlugin implements webpack.WebpackPluginInstance {
           // 1. Aggregate modules to process
           compilation.modules.forEach((module: webpack.Module) => {
             // Ignore already built modules for webpack 5
-            if (isWebpack5 && compilation.builtModules.has(module)) {
+            if (isWebpack5 && !compilation.builtModules.has(module)) {
               // eslint-disable-next-line
               // @ts-ignore: Webpack 4 type
               debugExclude(`Ignoring un-built module: ${module.userRequest}`);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -185,6 +185,39 @@ export default class DocgenPlugin implements webpack.WebpackPluginInstance {
 
           // 1. Aggregate modules to process
           compilation.modules.forEach((module: webpack.Module) => {
+            // Ignore already built modules (webpack 4 only!).
+            // The question is, how to do the same in webpack 5?
+            // eslint-disable-next-line
+            // @ts-ignore: Webpack 4 type
+            if (!isWebpack5 && !module.built) {
+              // eslint-disable-next-line
+              // @ts-ignore: Webpack 4 type
+              debugExclude(`Ignoring un-built module: ${module.userRequest}`);
+              return;
+            }
+
+            // Ignore external modules
+            // eslint-disable-next-line
+            // @ts-ignore: Webpack 4 type
+            if (module.external) {
+              // eslint-disable-next-line
+              // @ts-ignore: Webpack 4 type
+              debugExclude(`Ignoring external module: ${module.userRequest}`);
+              return;
+            }
+
+            // Ignore raw requests
+            // eslint-disable-next-line
+            // @ts-ignore: Webpack 4 type
+            if (!module.rawRequest) {
+              debugExclude(
+                // eslint-disable-next-line
+                // @ts-ignore: Webpack 4 type
+                `Ignoring module without "rawRequest": ${module.userRequest}`
+              );
+              return;
+            }
+
             if (!module.nameForCondition) {
               return;
             }


### PR DESCRIPTION
It turns out those checks were needed. I also found a way to do the same in webpack 5 so it should be faster as well (https://github.com/storybookjs/storybook/issues/15423#issuecomment-870813425).