### PR TITLE
feat: pass tags from jsdocs

### DIFF
--- a/src/__tests__/__fixtures__/Tags.tsx
+++ b/src/__tests__/__fixtures__/Tags.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+interface ComponentWithTaggedProps {
+  /**
+   * Button color.
+   *
+   * @hidden always
+   */
+  color: "blue" | "green";
+}
+
+/**
+ * A component with tags.
+ *
+ * @since now
+ */
+export const TaggedComponent: React.FC<ComponentWithTaggedProps> = (props) => (
+  <button style={{ backgroundColor: props.color }}>{props.children}</button>
+);

--- a/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
+++ b/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
@@ -19,7 +19,7 @@ try {
     // @ts-ignore
     SimpleComponent.displayName = \\"SimpleComponent\\";
     // @ts-ignore
-    SimpleComponent.__docgenInfo = { \\"description\\": \\"A simple component.\\", \\"displayName\\": \\"SimpleComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+    SimpleComponent.__docgenInfo = { \\"description\\": \\"A simple component.\\", \\"tags\\": {}, \\"displayName\\": \\"SimpleComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
     // @ts-ignore
     if (typeof STORYBOOK_REACT_CLASSES !== \\"undefined\\")
         // @ts-ignore
@@ -71,7 +71,7 @@ try {
     // @ts-ignore
     DefaultPropValueComponent.displayName = \\"DefaultPropValueComponent\\";
     // @ts-ignore
-    DefaultPropValueComponent.__docgenInfo = { \\"description\\": \\"Component with a prop with a default value.\\", \\"displayName\\": \\"DefaultPropValueComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": { value: \\"blue\\" }, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } }, \\"counter\\": { \\"defaultValue\\": { value: 123 }, \\"description\\": \\"Button counter.\\", \\"name\\": \\"counter\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"number\\" } }, \\"disabled\\": { \\"defaultValue\\": { value: false }, \\"description\\": \\"Button disabled.\\", \\"name\\": \\"disabled\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"boolean\\" } } } };
+    DefaultPropValueComponent.__docgenInfo = { \\"description\\": \\"Component with a prop with a default value.\\", \\"tags\\": {}, \\"displayName\\": \\"DefaultPropValueComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": { value: \\"blue\\" }, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } }, \\"counter\\": { \\"defaultValue\\": { value: 123 }, \\"description\\": \\"Button counter.\\", \\"name\\": \\"counter\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"number\\" } }, \\"disabled\\": { \\"defaultValue\\": { value: false }, \\"description\\": \\"Button disabled.\\", \\"name\\": \\"disabled\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"boolean\\" } } } };
 }
 catch (__react_docgen_typescript_loader_error) { }"
 `;
@@ -99,7 +99,7 @@ try {
     // @ts-ignore
     HyphenatedPropNameComponent.displayName = \\"HyphenatedPropNameComponent\\";
     // @ts-ignore
-    HyphenatedPropNameComponent.__docgenInfo = { \\"description\\": \\"A component with a hyphenated prop name.\\", \\"displayName\\": \\"HyphenatedPropNameComponent\\", \\"props\\": { \\"button-color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"button-color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+    HyphenatedPropNameComponent.__docgenInfo = { \\"description\\": \\"A component with a hyphenated prop name.\\", \\"tags\\": {}, \\"displayName\\": \\"HyphenatedPropNameComponent\\", \\"props\\": { \\"button-color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"button-color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
 }
 catch (__react_docgen_typescript_loader_error) { }"
 `;
@@ -126,7 +126,7 @@ try {
     // @ts-ignore
     MultiPropsComponent.displayName = \\"MultiPropsComponent\\";
     // @ts-ignore
-    MultiPropsComponent.__docgenInfo = { \\"description\\": \\"This is a component with multiple props.\\", \\"displayName\\": \\"MultiPropsComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } }, \\"size\\": { \\"defaultValue\\": null, \\"description\\": \\"Button size.\\", \\"name\\": \\"size\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"small\\\\\\" | \\\\\\"large\\\\\\"\\" } } } };
+    MultiPropsComponent.__docgenInfo = { \\"description\\": \\"This is a component with multiple props.\\", \\"tags\\": {}, \\"displayName\\": \\"MultiPropsComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } }, \\"size\\": { \\"defaultValue\\": null, \\"description\\": \\"Button size.\\", \\"name\\": \\"size\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"small\\\\\\" | \\\\\\"large\\\\\\"\\" } } } };
 }
 catch (__react_docgen_typescript_loader_error) { }"
 `;
@@ -152,7 +152,7 @@ try {
     // @ts-ignore
     MultilineDescriptionComponent.displayName = \\"MultilineDescriptionComponent\\";
     // @ts-ignore
-    MultilineDescriptionComponent.__docgenInfo = { \\"description\\": \\"A component with a multiline description.\\\\n\\\\nSecond line.\\", \\"displayName\\": \\"MultilineDescriptionComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+    MultilineDescriptionComponent.__docgenInfo = { \\"description\\": \\"A component with a multiline description.\\\\n\\\\nSecond line.\\", \\"tags\\": {}, \\"displayName\\": \\"MultilineDescriptionComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
 }
 catch (__react_docgen_typescript_loader_error) { }"
 `;
@@ -180,7 +180,7 @@ try {
     // @ts-ignore
     MultilinePropDescriptionComponent.displayName = \\"MultilinePropDescriptionComponent\\";
     // @ts-ignore
-    MultilinePropDescriptionComponent.__docgenInfo = { \\"description\\": \\"A component with multiline prop description.\\", \\"displayName\\": \\"MultilinePropDescriptionComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"This is a multiline prop description.\\\\n\\\\nSecond line.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+    MultilinePropDescriptionComponent.__docgenInfo = { \\"description\\": \\"A component with multiline prop description.\\", \\"tags\\": {}, \\"displayName\\": \\"MultilinePropDescriptionComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"This is a multiline prop description.\\\\n\\\\nSecond line.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
 }
 catch (__react_docgen_typescript_loader_error) { }"
 `;
@@ -204,7 +204,37 @@ try {
     // @ts-ignore
     SimpleComponent.displayName = \\"SimpleComponent\\";
     // @ts-ignore
-    SimpleComponent.__docgenInfo = { \\"description\\": \\"A simple component.\\", \\"displayName\\": \\"SimpleComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+    SimpleComponent.__docgenInfo = { \\"description\\": \\"A simple component.\\", \\"tags\\": {}, \\"displayName\\": \\"SimpleComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
+exports[`component fixture Tags.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface ComponentWithTaggedProps {
+  /**
+   * Button color.
+   *
+   * @hidden always
+   */
+  color: \\"blue\\" | \\"green\\";
+}
+
+/**
+ * A component with tags.
+ *
+ * @since now
+ */
+export const TaggedComponent: React.FC<ComponentWithTaggedProps> = (props) => (
+  <button style={{ backgroundColor: props.color }}>{props.children}</button>
+);
+
+try {
+    // @ts-ignore
+    TaggedComponent.displayName = \\"TaggedComponent\\";
+    // @ts-ignore
+    TaggedComponent.__docgenInfo = { \\"description\\": \\"A component with tags.\\", \\"tags\\": { \\"since\\": \\"now\\" }, \\"displayName\\": \\"TaggedComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\\\n@hidden always\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
 }
 catch (__react_docgen_typescript_loader_error) { }"
 `;
@@ -225,7 +255,7 @@ try {
     // @ts-ignore
     SimpleComponent.displayName = \\"SimpleComponent\\";
     // @ts-ignore
-    SimpleComponent.__docgenInfo = { \\"description\\": \\"A component with only text content wrapped in a div.\\\\n\\\\nRef: https://github.com/strothj/react-docgen-typescript-loader/issues/7\\", \\"displayName\\": \\"SimpleComponent\\", \\"props\\": {} };
+    SimpleComponent.__docgenInfo = { \\"description\\": \\"A component with only text content wrapped in a div.\\\\n\\\\nRef: https://github.com/strothj/react-docgen-typescript-loader/issues/7\\", \\"tags\\": {}, \\"displayName\\": \\"SimpleComponent\\", \\"props\\": {} };
 }
 catch (__react_docgen_typescript_loader_error) { }"
 `;
@@ -273,7 +303,7 @@ try {
     // @ts-ignore
     DefaultPropValueComponent.displayName = \\"DefaultPropValueComponent\\";
     // @ts-ignore
-    DefaultPropValueComponent.__docgenInfo = { \\"description\\": \\"Component with a prop with a default value.\\", \\"displayName\\": \\"DefaultPropValueComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": { value: \\"blue\\" }, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"enum\\", \\"value\\": [{ \\"value\\": \\"\\\\\\"blue\\\\\\"\\" }, { \\"value\\": \\"\\\\\\"green\\\\\\"\\" }] } }, \\"counter\\": { \\"defaultValue\\": { value: 123 }, \\"description\\": \\"Button counter.\\", \\"name\\": \\"counter\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"number\\" } }, \\"disabled\\": { \\"defaultValue\\": { value: false }, \\"description\\": \\"Button disabled.\\", \\"name\\": \\"disabled\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"boolean\\" } } } };
+    DefaultPropValueComponent.__docgenInfo = { \\"description\\": \\"Component with a prop with a default value.\\", \\"tags\\": {}, \\"displayName\\": \\"DefaultPropValueComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": { value: \\"blue\\" }, \\"description\\": \\"Button color.\\", \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"enum\\", \\"value\\": [{ \\"value\\": \\"\\\\\\"blue\\\\\\"\\" }, { \\"value\\": \\"\\\\\\"green\\\\\\"\\" }] } }, \\"counter\\": { \\"defaultValue\\": { value: 123 }, \\"description\\": \\"Button counter.\\", \\"name\\": \\"counter\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"number\\" } }, \\"disabled\\": { \\"defaultValue\\": { value: false }, \\"description\\": \\"Button disabled.\\", \\"name\\": \\"disabled\\", \\"required\\": false, \\"type\\": { \\"name\\": \\"boolean\\" } } } };
 }
 catch (__react_docgen_typescript_loader_error) { }"
 `;

--- a/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
+++ b/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
@@ -260,6 +260,36 @@ try {
 catch (__react_docgen_typescript_loader_error) { }"
 `;
 
+exports[`generates tag map info for props 1`] = `
+"import * as React from \\"react\\";
+
+interface ComponentWithTaggedProps {
+  /**
+   * Button color.
+   *
+   * @hidden always
+   */
+  color: \\"blue\\" | \\"green\\";
+}
+
+/**
+ * A component with tags.
+ *
+ * @since now
+ */
+export const TaggedComponent: React.FC<ComponentWithTaggedProps> = (props) => (
+  <button style={{ backgroundColor: props.color }}>{props.children}</button>
+);
+
+try {
+    // @ts-ignore
+    TaggedComponent.displayName = \\"TaggedComponent\\";
+    // @ts-ignore
+    TaggedComponent.__docgenInfo = { \\"description\\": \\"A component with tags.\\", \\"tags\\": { \\"since\\": \\"now\\" }, \\"displayName\\": \\"TaggedComponent\\", \\"props\\": { \\"color\\": { \\"defaultValue\\": null, \\"description\\": \\"Button color.\\", \\"tags\\": { \\"hidden\\": \\"always\\" }, \\"name\\": \\"color\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"\\\\\\"blue\\\\\\" | \\\\\\"green\\\\\\"\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
 exports[`generates value info for enums 1`] = `
 "import * as React from \\"react\\";
 

--- a/src/__tests__/generateDocgenCodeBlock.test.ts
+++ b/src/__tests__/generateDocgenCodeBlock.test.ts
@@ -58,3 +58,13 @@ it("generates value info for enums", () => {
     )
   ).toMatchSnapshot();
 });
+
+it("generates tag map info for props", () => {
+  expect(
+    generateDocgenCodeBlock(
+      getGeneratorOptions({ shouldIncludePropTagMap: true })(
+        "Tags.tsx"
+      )
+    )
+  ).toMatchSnapshot();
+});

--- a/src/generateDocgenCodeBlock.ts
+++ b/src/generateDocgenCodeBlock.ts
@@ -131,6 +131,22 @@ function createPropDefinition(
 
   /**
    * ```
+   * SimpleComponent.__docgenInfo.props.someProp.tags = { "tagName": "tagValue" };
+   * ```
+   * @param tags Prop tags.
+   */
+  const setTags = (tags: Record<string, string>) =>
+      ts.createPropertyAssignment(
+        ts.createLiteral("tags"),
+        ts.createObjectLiteral(
+            Object.entries(tags).map(([tagName, tagValue]) =>
+                setStringLiteralField(tagName, tagValue)
+            )
+        )
+      );
+
+  /**
+   * ```
    * SimpleComponent.__docgenInfo.props.someProp.name = "someProp";
    * ```
    * @param name Prop name.
@@ -199,6 +215,7 @@ function createPropDefinition(
     ts.createObjectLiteral([
       setDefaultValue(prop.defaultValue),
       setDescription(prop.description),
+      ...(prop.tags ? [setTags(prop.tags)] : []),
       setName(prop.name),
       setRequired(prop.required),
       setType(prop.type.name, prop.type.value),
@@ -301,6 +318,18 @@ function setComponentDocGen(
             ts.createLiteral("description"),
             ts.createLiteral(d.description)
           ),
+          // SimpleComponent.__docgenInfo.tags
+          ...(d.tags ? [ts.createPropertyAssignment(
+              ts.createLiteral("tags"),
+              ts.createObjectLiteral(
+                  Object.entries<string>(d.tags).map(([tagName, tagValue]) =>
+                      ts.createPropertyAssignment(
+                          ts.createLiteral(tagName),
+                          ts.createLiteral(tagValue)
+                      )
+                  )
+              )
+          )] : []),
           // SimpleComponent.__docgenInfo.displayName
           ts.createPropertyAssignment(
             ts.createLiteral("displayName"),


### PR DESCRIPTION
The `react-docgen-typescript` library passes tags from JSDocs which `react-docgen-typescript-plugin` ignores. This pull request amends this so that `tags` metadata is passed appropriately into the generated code.

Please release it so that it's working also (or predominantly) with `webpack@4` [no problems here I guess] and `react-docgen-typescript@1` [I’ve noticed there’re plans to bump to `@2`] as those are versions I am bound for now in code I maintain. Thanks in advance!