### PR TITLE
Use component expression name as identifier

### DIFF
--- a/src/__tests__/__fixtures__/DisplayName.tsx
+++ b/src/__tests__/__fixtures__/DisplayName.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+interface ButtonComponentProps {
+  text: string;
+}
+
+export const Button = (props: ButtonComponentProps) => (
+  <button>{props.text}</button>
+);
+
+Button.displayName = "MyButtonDisplayName";

--- a/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
+++ b/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
@@ -93,7 +93,7 @@ try {
     // @ts-ignore
     MyButtonDisplayName.displayName = \\"MyButtonDisplayName\\";
     // @ts-ignore
-    MyButtonDisplayName.__docgenInfo = { \\"description\\": \\"\\", \\"displayName\\": \\"MyButtonDisplayName\\", \\"props\\": { \\"text\\": { \\"defaultValue\\": null, \\"description\\": \\"\\", \\"name\\": \\"text\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"string\\" } } } };
+    Button.__docgenInfo = { \\"description\\": \\"\\", \\"displayName\\": \\"MyButtonDisplayName\\", \\"props\\": { \\"text\\": { \\"defaultValue\\": null, \\"description\\": \\"\\", \\"name\\": \\"text\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"string\\" } } } };
 }
 catch (__react_docgen_typescript_loader_error) { }"
 `;

--- a/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
+++ b/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
@@ -76,6 +76,28 @@ try {
 catch (__react_docgen_typescript_loader_error) { }"
 `;
 
+exports[`component fixture DisplayName.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+interface ButtonComponentProps {
+  text: string;
+}
+
+export const Button = (props: ButtonComponentProps) => (
+  <button>{props.text}</button>
+);
+
+Button.displayName = \\"MyButtonDisplayName\\";
+
+try {
+    // @ts-ignore
+    MyButtonDisplayName.displayName = \\"MyButtonDisplayName\\";
+    // @ts-ignore
+    MyButtonDisplayName.__docgenInfo = { \\"description\\": \\"\\", \\"displayName\\": \\"MyButtonDisplayName\\", \\"props\\": { \\"text\\": { \\"defaultValue\\": null, \\"description\\": \\"\\", \\"name\\": \\"text\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"string\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
 exports[`component fixture HyphenatedPropName.tsx has code block generated 1`] = `
 "import * as React from \\"react\\";
 

--- a/src/__tests__/generateDocgenCodeBlock.test.ts
+++ b/src/__tests__/generateDocgenCodeBlock.test.ts
@@ -6,7 +6,9 @@ import {
   GeneratorOptions,
 } from "../generateDocgenCodeBlock";
 
-function getGeneratorOptions(parserOptions: ParserOptions = {}) {
+const defaultParserOptions = { shouldIncludeExpression: true };
+
+function getGeneratorOptions(parserOptions: ParserOptions) {
   return (filename: string) => {
     const filePath = path.resolve(__dirname, "__fixtures__", filename);
 
@@ -24,7 +26,7 @@ function getGeneratorOptions(parserOptions: ParserOptions = {}) {
 function loadFixtureTests(): GeneratorOptions[] {
   return fs
     .readdirSync(path.resolve(__dirname, "__fixtures__"))
-    .map(getGeneratorOptions());
+    .map(getGeneratorOptions(defaultParserOptions));
 }
 
 const fixtureTests: GeneratorOptions[] = loadFixtureTests();
@@ -52,9 +54,10 @@ it("adds component to docgen collection", () => {
 it("generates value info for enums", () => {
   expect(
     generateDocgenCodeBlock(
-      getGeneratorOptions({ shouldExtractLiteralValuesFromEnum: true })(
-        "DefaultPropValue.tsx"
-      )
+      getGeneratorOptions({
+        ...defaultParserOptions,
+        shouldExtractLiteralValuesFromEnum: true,
+      })("DefaultPropValue.tsx")
     )
   ).toMatchSnapshot();
 });

--- a/src/generateDocgenCodeBlock.ts
+++ b/src/generateDocgenCodeBlock.ts
@@ -305,7 +305,7 @@ function setComponentDocGen(
       ts.factory.createBinaryExpression(
         // SimpleComponent.__docgenInfo
         ts.factory.createPropertyAccessExpression(
-          ts.factory.createIdentifier(d.displayName),
+          ts.factory.createIdentifier(d.expression?.getName() || d.displayName),
           ts.factory.createIdentifier("__docgenInfo")
         ),
         ts.SyntaxKind.EqualsToken,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -405,7 +405,10 @@ export default class DocgenPlugin implements webpack.WebpackPluginInstance {
     }
 
     return {
-      docgenOptions,
+      docgenOptions: {
+        shouldIncludeExpression: true,
+        ...docgenOptions,
+      },
       generateOptions: {
         docgenCollectionName:
           docgenCollectionName === undefined


### PR DESCRIPTION
Fixes #51 cc @leepowelldev

This PR uses the new functionality added to `react-docgen-typescript@2.2.1` (see https://github.com/styleguidist/react-docgen-typescript/pull/398 to get the correct identifier for components when they have a `displayName` that doesn't match up.

Unfortunately, this is blocked by #43, since it requires a new major version of `react-docgen-typescript`. In addition to requiring `typescript >= 4.3.x`, the new `react-docgen-typescript` version breaks the test snapshots involving `defaultValue`:

```
# Before
"defaultValue": { value: "blue" }

# After
"defaultValue": null
```

I'm not sure why that is. So for now, I'm just pushing this branch up as a draft PR.