### PR TITLE
Demonstrate invalid syntax when using sub components

### DIFF
--- a/src/__tests__/__fixtures__/SubComponent.tsx
+++ b/src/__tests__/__fixtures__/SubComponent.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+export default function Root(props: { name: string }) {
+  return <span>root {props.name}</span>;
+}
+
+function Sub(props: { name: string }) {
+  return <span>sub {props.name}</span>;
+}
+
+Root.Sub = Sub;

--- a/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
+++ b/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
@@ -209,6 +209,35 @@ try {
 catch (__react_docgen_typescript_loader_error) { }"
 `;
 
+exports[`component fixture SubComponent.tsx has code block generated 1`] = `
+"import * as React from \\"react\\";
+
+export default function Root(props: { name: string }) {
+  return <span>root {props.name}</span>;
+}
+
+function Sub(props: { name: string }) {
+  return <span>sub {props.name}</span>;
+}
+
+Root.Sub = Sub;
+
+try {
+    // @ts-ignore
+    SubComponent.displayName = \\"SubComponent\\";
+    // @ts-ignore
+    SubComponent.__docgenInfo = { \\"description\\": \\"\\", \\"displayName\\": \\"SubComponent\\", \\"props\\": { \\"name\\": { \\"defaultValue\\": null, \\"description\\": \\"\\", \\"name\\": \\"name\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"string\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }
+try {
+    // @ts-ignore
+    default.Sub.displayName = \\"default.Sub\\";
+    // @ts-ignore
+    default.Sub.__docgenInfo = { \\"description\\": \\"\\", \\"displayName\\": \\"default.Sub\\", \\"props\\": { \\"name\\": { \\"defaultValue\\": null, \\"description\\": \\"\\", \\"name\\": \\"name\\", \\"required\\": true, \\"type\\": { \\"name\\": \\"string\\" } } } };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
 exports[`component fixture TextOnlyComponent.tsx has code block generated 1`] = `
 "import * as React from \\"react\\";
 


### PR DESCRIPTION
This PR is meant to demonstrate/add a test case for the invalid output described in #57. It stems from a bug in `react-docgen-typescript` where components that are assigned to properties of other components are given a name of `default.Name`.

The snapshot that gets generated by the test suite for this (valid) file contains a syntax error.