### PR TITLE
fix: Remove unused `endent` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   ],
   "dependencies": {
     "debug": "^4.1.1",
-    "endent": "^2.0.1",
     "find-cache-dir": "^3.3.1",
     "flat-cache": "^3.0.4",
     "micromatch": "^4.0.2",


### PR DESCRIPTION
Unless I'm mistaken, the `endent` dependency is not used at all, so I've removed it.