### PR TITLE
fix: use correct component identifier throughout docblock

### DIFF
--- a/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
+++ b/src/__tests__/__snapshots__/generateDocgenCodeBlock.test.ts.snap
@@ -28,6 +28,30 @@ try {
 catch (__react_docgen_typescript_loader_error) { }"
 `;
 
+exports[`adds component with display name to docgen collection 1`] = `
+"import * as React from "react";
+
+interface ButtonComponentProps {
+  text: string;
+}
+
+export const Button = (props: ButtonComponentProps) => (
+  <button>{props.text}</button>
+);
+
+Button.displayName = "MyButtonDisplayName";
+
+try {
+    // @ts-ignore
+    Button.__docgenInfo = { "description": "", "displayName": "MyButtonDisplayName", "props": { "text": { "defaultValue": null, "description": "", "name": "text", "required": true, "type": { "name": "string" } } } };
+    // @ts-ignore
+    if (typeof STORYBOOK_REACT_CLASSES !== "undefined")
+        // @ts-ignore
+        STORYBOOK_REACT_CLASSES["DisplayName.tsx#MyButtonDisplayName"] = { docgenInfo: Button.__docgenInfo, name: "MyButtonDisplayName", path: "DisplayName.tsx#MyButtonDisplayName" };
+}
+catch (__react_docgen_typescript_loader_error) { }"
+`;
+
 exports[`component fixture DefaultPropValue.tsx has code block generated 1`] = `
 "import * as React from "react";
 
@@ -93,8 +117,6 @@ export const Button = (props: ButtonComponentProps) => (
 Button.displayName = "MyButtonDisplayName";
 
 try {
-    // @ts-ignore
-    MyButtonDisplayName.displayName = "MyButtonDisplayName";
     // @ts-ignore
     Button.__docgenInfo = { "description": "", "displayName": "MyButtonDisplayName", "props": { "text": { "defaultValue": null, "description": "", "name": "text", "required": true, "type": { "name": "string" } } } };
 }

--- a/src/__tests__/generateDocgenCodeBlock.test.ts
+++ b/src/__tests__/generateDocgenCodeBlock.test.ts
@@ -30,9 +30,8 @@ function loadFixtureTests(): GeneratorOptions[] {
 }
 
 const fixtureTests: GeneratorOptions[] = loadFixtureTests();
-const simpleFixture = fixtureTests.find(
-  (f) => f.filename === "Simple.tsx"
-) as GeneratorOptions;
+const simpleFixture = fixtureTests.find((f) => f.filename === "Simple.tsx")!
+const displayNameFixture = fixtureTests.find((f) => f.filename === "DisplayName.tsx")!
 
 describe("component fixture", () => {
   fixtureTests.forEach((generatorOptions) => {
@@ -46,6 +45,15 @@ it("adds component to docgen collection", () => {
   expect(
     generateDocgenCodeBlock({
       ...simpleFixture,
+      docgenCollectionName: "STORYBOOK_REACT_CLASSES",
+    })
+  ).toMatchSnapshot();
+});
+
+it("adds component with display name to docgen collection", () => {
+  expect(
+    generateDocgenCodeBlock({
+      ...displayNameFixture,
       docgenCollectionName: "STORYBOOK_REACT_CLASSES",
     })
   ).toMatchSnapshot();


### PR DESCRIPTION
Fixes #91.

PR #58 specifically fixed the identifier problem for `__docgenInfo`, but it did not fix it for setting `displayName` or within the global collection object. This PR applies the same identifier change to fix these other two spots.

I also made a change to `setDisplayName`, that skips adding the `displayName` if we know that the identifier doesn't match the display name. In this case, it follows that the component must have already set `displayName`, and it didn't make sense to me that we should set the same property twice. This change isn't strictly necessary, so if you'd rather drop it, I don't mind.