### PR TITLE
Bump flat-cache to latest version (caveat)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "find-cache-dir": "^3.3.1",
-    "flat-cache": "^3.0.4",
+    "flat-cache": "^5.x",
     "micromatch": "^4.0.2",
     "react-docgen-typescript": "^2.2.2",
     "tslib": "^2.6.2"


### PR DESCRIPTION
On my machine (macOS Monterey 12.7.2, npm 10.8.1, node 22) the tests completed.

However, running `npm install` will still throw warns about glob, rimraf, etc. This is because the current version of jest hasn't been updated yet - jest's version "3.0.0-alpha5" bumps all these packages (https://github.com/jestjs/jest/blob/main/package.json).  