### PR TITLE
Bump micromatch to 4.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "debug": "^4.1.1",
     "find-cache-dir": "^3.3.1",
     "flat-cache": "^3.0.4",
-    "micromatch": "^4.0.2",
+    "micromatch": "^4.0.6",
     "react-docgen-typescript": "^2.2.2",
     "tslib": "^2.6.2"
   },


### PR DESCRIPTION
Stumbled across this on a react-project: braces@3.0.2 has a bug: [CVE-2024-4068](https://github.com/advisories/GHSA-grv7-fg5c-xmjg) which could lead to OOM errors (apparently not easy to trigger, but I managed to do it somehow). braces@3.0.2 was used in micromatch@4.0.5.

Couldn't find any mentions of either micromatch or braces in issues/PR's.

This was pretty deep down in our monorepo dependency graph 😅 :
```
➜  storeblocks git:(main) npm ls braces 
storybook@ /Users/me/some-dir/storeblocks
├─┬ react-docgen-typescript-plugin@1.0.6
│ └─┬ micromatch@4.0.5
│   └── braces@3.0.2
└─┬ typescript-plugin-css-modules@5.1.0
  └─┬ sass@1.75.0
    └─┬ chokidar@3.6.0
      └── braces@3.0.2 deduped
```

Error trace (snipped):
```
✖  nx run @storeblocks/table:lint
      Linting "@storeblocks/table"...
      <--- Last few GCs --->
      [31879:0x148008000]    29784 ms: Mark-Compact 4042.9 (4138.1) -> 4033.1 (4141.6) MB, pooled: 2 MB, 1509.42 / 0.00 ms  (average mu = 0.303, current mu = 0.011) allocation failure; scavenge might not succeed
      <--- JS stacktrace --->
      FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

Micromatch@4.0.6 commit which updated braces to 3.0.3: https://github.com/micromatch/micromatch/commit/92d490dd23da0d02bdc2414ed3929a185a464218

I'm no expert on react-docgen-typescript-plugin (or TS in general), so if I'm wrong you may just close this. Also I'm not sure if `@types/micromatch` should be updated also.

Anyhow, thanks for creating and open sourcing this package ❤️ 